### PR TITLE
[AST-3438] Prepare GitHub Action for open source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report for a bug in the GitHub Action
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Actual behavior
+A clear and concise description of where the behavior differed from the expected behavior
+
+### Steps to reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Additional comments
+Add any other context about the problem here.
+
+### Logs
+Paste the output from your execution. Redact if needed.

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,0 +1,17 @@
+---
+name: Enhancement request
+about: Suggest a new feature for the GitHub Action
+title: "[REQ]"
+labels: enhancement
+assignees: ''
+
+---
+
+### Is your request related to a workflow problem?
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Propose a solution
+A clear and concise description of what you want to happen.
+
+### Additional comments
+Add any other context, alternative solutions, current workarounds or screenshots about the request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.
+
+### Description
+
+> Describe the purpose of this PR along with any background information and the impacts of the proposed change.
+
+### References
+
+> Include supporting link to GitHub Issue/PR number
+
+### Testing
+
+> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
+>
+> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
+
+### Checklist
+
+- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
+- [ ] All active GitHub checks for tests, formatting, and security are passing
+- [ ] The correct base branch is being used

--- a/README.md
+++ b/README.md
@@ -64,13 +64,16 @@ _Note: It is recommended to leverage secrets for any sensitive inputs_
 * [Github PUSH workflow for AST](sample-yml/checkmarx-ast-scan-push.yml)
 * [Github PULL REQUEST workflow for AST](sample-yml/checkmarx-ast-scan-pull-request.yml)
 
-## How To Contribute
+## Contribution
 
-We welcome [issues](https://github.com/checkmarxDev/ast-github-action/issues) to and [pull requests](https://github.com/checkmarxDev/ast-github-action/pulls) against this repository!
+We appreciate feedback and contribution to the GitHub Action! Before you get started, please see the following:
+
+- [Checkmarx contribution guidelines](docs/contributing.md)
+- [Checkmarx Code of Conduct](docs/code_of_conduct.md)
 
 # License
 
-Checkmarx Github Action
+Checkmarx GitHub Action
 
 Copyright (C) 2021 Checkmarx
 

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,79 @@
+# Contributing to AST GitHub Action
+
+Welcome and thank you for considering contributing to the AST GitHub Action
+
+Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the developers managing and developing these open source projects. In return, we will reciprocate that respect by addressing your issue, assessing changes, and helping you finalize your pull requests.
+
+
+## Quicklinks
+
+- [Contributing to AST GitHub Action](#contributing-to-ast-github-action)
+    - [Quicklinks](#quicklinks)
+    - [Code of Conduct](#code-of-conduct)
+    - [Getting Started](#getting-started)
+    - [Issues](#issues)
+        - [Templates](#templates)
+    - [Pull Requests](#pull-requests)
+        - [Templates](#templates-1)
+    - [Resources](#resources)
+
+## Code of Conduct
+
+By participating and contributing to any Checkmarx projects, you agree to uphold our [Code of Conduct](code_of_conduct.md).
+
+## Getting Started
+
+If you have suggestions for how this project could be improved, or want to report a bug, open an issue. We appreciate all contributions. If you have questions, we'd love to hear them.
+
+We also appreciate PRs.  If you're thinking of submitting any PR, pleae open an issue first to spark a discussion around it.
+
+Contributions are made to this repo via Issues and Pull Requests (PRs).  A few general guidelines that cover both:
+
+- Search for existing Issues and PRs before creating your own to avoid duplicates.
+- PRs will only be accepted if associated with an issue (enhancement or bug) that has been submitted and reviewed/labeld as *accepted* by a Checkmarx team member.
+- We will work hard to makes sure issues that are raised are handled in a timely manner.
+
+## Issues
+
+Issues should be used to report problems with the solution / source code, request a new feature, or to discuss potential changes before a PR is created. When you create a new Issue, a template will be loaded that will guide you through collecting and providing the information we need to investigate.
+
+If you find an Issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help by indicating to our maintainers that a particular problem is affecting more than just the reporter.
+
+### Templates
+
+The following templates will be used within Checkmarx github repositories
+- [Enhancement/Feature Request Template](../.github/ISSUE_TEMPLATE/enhancement-request.md)
+- [Bug Report Template](../.github/ISSUE_TEMPLATE/bug_report.md)
+
+## Pull Requests
+
+PRs to our source are always welcome and can be a quick way to get your fix or improvement slated for the next release. In general, PRs should:
+
+- Only fix/add the functionality in question **or** address code style issues, not both.
+- Ensure all necessary details are provided and adhered to
+- Add unit or integration tests for fixed or changed functionality (if a test suite already exists) or specify steps taken to ensure changes were tested and functionality works as expected.
+- Address a single concern in the least number of changed lines as possible.
+- Include documentation in the repo or Provide additional comments in Markdown comments that should be pulled/reflected in GitHub Wiki for the given project.
+- Be accompanied by a complete Pull Request template (loaded automatically when a PR is created).
+
+For changes that address core functionality or would require breaking changes (e.g. a major release), please open an Issue to discuss your proposal first.
+
+In general, we follow the _fork-and-pull_ Git workflow
+
+1. Fork the repository to your own Github account
+2. Clone the project to your machine
+3. Create a branch locally with a succinct but descriptive name (prefix with feature/<issue#>-descriptive-name> or hotfix/<issue#>-descriptive-name)
+4. Commit changes to the branch
+5. Push changes to your fork
+6. Open a PR in our repository and follow the PR template so that we can efficiently review and asses the changes.  *Ensure an associated Issue has been accepted by the Checkmarx team.*
+
+### Templates
+The following template will be used within Checkmarx github repositories
+
+[Pull Request Template](../.github/PULL_REQUEST_TEMPLATE.md)
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)


### PR DESCRIPTION
- Add templates for bug report, feature request and pull request
- Add code of conduct
- Add contribution guide
- Update readme with links to code of conduct and contribution guide