### PR TITLE
Ast 10425 fix pr branch override

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Select a Checkmarx Project Name'
   branch:
     required: false
-    default: ${{ github.ref }}
+    default: ${{ github.head_ref }} # default branch name
     description: 'Branch name'
   github_token:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Select a Checkmarx Project Name'
   branch:
     required: false
-    default: ${{ github.head_ref }} # default branch name
+    default: ${{ github.head_ref || github.ref }} # default branch name
     description: 'Branch name'
   github_token:
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ echo "Branch name: " ${BRANCH}
 echo "Branch from github: " ${GITHUB_HEAD_REF}
 
 eval "arr=(${ADDITIONAL_PARAMS})"
-/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/:-${GITHUB_HEAD_REF}}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
+/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
 exitCode=${PIPESTATUS[0]}
 
 echo "Program exits with code: " $exitCode

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+BRANCH_VAL = ${BRANCH}
+if [ -z "$BRANCH_VAL" ]
+  then
+    BRANCH_VAL = ${GITHUB_HEAD_REF}
+  ELSE
+    BRANCH_VAL = ${BRANCH}
+fi
+
 eval "arr=(${ADDITIONAL_PARAMS})"
-/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${GITHUB_HEAD_REF:-${BRANCH#refs/heads/}}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
+/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH_VAL}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
 exitCode=${PIPESTATUS[0]}
 
 echo "Program exits with code: " $exitCode

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-BRANCH_VAL = ${BRANCH}
+BRANCH_VAL = "${BRANCH}"
 if [ -z "$BRANCH_VAL" ]
   then
     BRANCH_VAL = ${GITHUB_HEAD_REF}
+    echo "BRANCH_VAL is empty, using GITHUB_HEAD_REF: $BRANCH_VAL"
   ELSE
     BRANCH_VAL = ${BRANCH}
+    echo "BRANCH_VAL is not empty, using BRANCH: $BRANCH_VAL"
 fi
 
 eval "arr=(${ADDITIONAL_PARAMS})"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+echo "Starting the application..."
+echo "Environment variables:" $@
+echo "Branch ref: " ${BRANCH#refs/heads/}
+echo "Branch name: " ${BRANCH}
+echo "Branch from github: " ${GITHUB_HEAD_REF}
+
 eval "arr=(${ADDITIONAL_PARAMS})"
 /app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${GITHUB_HEAD_REF:-${BRANCH#refs/heads/}}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
 exitCode=${PIPESTATUS[0]}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-echo "Starting the application..."
-echo "Environment variables:" $@
-echo "Branch ref: " ${BRANCH#refs/heads/}
-echo "Branch name: " ${BRANCH}
-echo "Branch from github: " ${GITHUB_HEAD_REF}
-
 eval "arr=(${ADDITIONAL_PARAMS})"
 /app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
 exitCode=${PIPESTATUS[0]}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,7 @@
 #!/bin/bash
 
-BRANCH_VAL = "${BRANCH}"
-if [ -z "$BRANCH_VAL" ]
-  then
-    BRANCH_VAL = ${GITHUB_HEAD_REF}
-    echo "BRANCH_VAL is empty, using GITHUB_HEAD_REF: $BRANCH_VAL"
-  ELSE
-    BRANCH_VAL = ${BRANCH}
-    echo "BRANCH_VAL is not empty, using BRANCH: $BRANCH_VAL"
-fi
-
 eval "arr=(${ADDITIONAL_PARAMS})"
-/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH_VAL}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
+/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${GITHUB_HEAD_REF:-${BRANCH#refs/heads/}}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
 exitCode=${PIPESTATUS[0]}
 
 echo "Program exits with code: " $exitCode

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ echo "Branch name: " ${BRANCH}
 echo "Branch from github: " ${GITHUB_HEAD_REF}
 
 eval "arr=(${ADDITIONAL_PARAMS})"
-/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${GITHUB_HEAD_REF:-${BRANCH#refs/heads/}}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
+/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/:-${GITHUB_HEAD_REF}}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
 exitCode=${PIPESTATUS[0]}
 
 echo "Program exits with code: " $exitCode


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Fix the default branch selection behavior incase of PR requests and the user sends a branch variable.

### References

> https://checkmarx.atlassian.net/browse/AST-10425

### Testing

>  Performed cases for the below
1. Scan on PR with no branch variable - must select the PR branch
2. Scan on PR with branch variable - must select the branch variable
3. Scan on non-PR branch with no branch variable - must select the non-PR branch
4. Scan on non-PR branch with a branch variable - must select the branch variable

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used