### PR TITLE
Use current directory instead of outputting logs to tmp

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cancelId=(`grep -E '"(ID)":"((\\"|[^"])*)"' /tmp/output.log | cut -d',' -f1 | cut -d':' -f2 | tr -d '"'`)
+cancelId=(`grep -E '"(ID)":"((\\"|[^"])*)"' ./output.log | cut -d',' -f1 | cut -d':' -f2 | tr -d '"'`)
 
 if [ -z "$cancelId" ]
 then 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 eval "arr=(${ADDITIONAL_PARAMS})"
-/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i /tmp/output.log
+/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i ./output.log
 exitCode=${PIPESTATUS[0]}
 
 echo "Program exits with code: " $exitCode


### PR DESCRIPTION
### Description

Use current directory instead of outputting logs to tmp so the cancel post action can access them.

### References

https://checkmarx.atlassian.net/browse/AST-15523

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used