### PR TITLE
Allow user to customize user agent

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     required: false
     default: ${{ github.event.number }}
     description: "Pr Number of the pull request that needs the decoration"
+  cx_agent:
+    required: false
+    default: "Github Action"
+    description: "A name for the origin of the scan"
 outputs: 
   cxcli:
     description: output from cli
@@ -66,6 +70,7 @@ runs:
   post-entrypoint: '/app/cleanup.sh'
 
   env:
+    CX_AGENT: "${{ inputs.cx_agent }}"
     CX_BASE_URI: "${{ inputs.base_uri }}"
     CX_TENANT: ${{ inputs.cx_tenant }}
     CX_CLIENT_ID: ${{ inputs.cx_client_id }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,9 @@
 output_file=./output.log
 
 eval "arr=(${ADDITIONAL_PARAMS})"
-/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i $output_file
+arr+=("--agent" "${CX_AGENT:-"Github Action"}")
+
+/app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json "${arr[@]}" | tee -i $output_file
 exitCode=${PIPESTATUS[0]}
 
 scanId=(`grep -E '"(ID)":"((\\"|[^"])*)"' $output_file | cut -d',' -f1 | cut -d':' -f2 | tr -d '"'`)


### PR DESCRIPTION
Allow user to specify a customized user agent via the `cx_agent` action input.

### Description

The user agent is currently enforced to "_Github Action_" however, it can be useful to specify a different value. We hijack this feature to set the agent to the commit hash or the build ID. This way, users have got a quick knowledge from the Checkmarx One interface as to which commit generated the scan. 

### References

- #148 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used