### PR TITLE
Action input to run scan asynchronously

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     required: false
     default: ${{ github.event.number }}
     description: "Pr Number of the pull request that needs the decoration"
+  scan_async:
+    required: false
+    default: ${{ false }}
+    description: "Do not wait for scan completion"
 outputs: 
   cxcli:
     description: output from cli
@@ -77,6 +81,7 @@ runs:
     REPO_NAME: ${{ inputs.repo_name }}
     NAMESPACE: ${{ inputs.namespace }}
     PR_NUMBER: ${{ inputs.pr_number }}
+    SCAN_ASYNC: ${{ inputs.scan_async }}
 
 branding:
   icon: 'check'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@
 output_file=./output.log
 
 eval "arr=(${ADDITIONAL_PARAMS})"
+[ "${SCAN_ASYNC}" == "true" ] && arr+=("--async")
+
 /app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i $output_file
 exitCode=${PIPESTATUS[0]}
 
@@ -16,7 +18,7 @@ else
 fi
 
 
-if [ -n "$scanId" ]; then
+if [ "${SCAN_ASYNC}" != "true" -a -n "$scanId" ]; then
   /app/bin/cx results show --scan-id "${scanId}" --report-format markdown 
   cat ./cx_result.md >$GITHUB_STEP_SUMMARY
   rm ./cx_result.md


### PR DESCRIPTION
### Description

Allow users to configure an asynchronous scan from the action input. Asynchronous scan is a common action so it is easier to set this via the action configuration.

### References

- #149 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used