### PR TITLE
Action input to set project groups

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     required: false
     default: ${{ github.repository }} # default repo name
     description: 'Select a Checkmarx Project Name'
+  project_groups:
+    required: false
+    description: 'A comma separated list of groups the project belongs to'
+    default: ''
   branch:
     required: false
     default: ${{ github.head_ref || github.ref }} # default branch name
@@ -73,6 +77,7 @@ runs:
     GITHUB_TOKEN: ${{ inputs.github_token }}
     BRANCH: ${{ inputs.branch }}
     PROJECT_NAME: ${{ inputs.project_name }}
+    PROJECT_GROUPS: ${{ inputs.project_groups }}
     ADDITIONAL_PARAMS: ${{ inputs.additional_params }}
     REPO_NAME: ${{ inputs.repo_name }}
     NAMESPACE: ${{ inputs.namespace }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@
 output_file=./output.log
 
 eval "arr=(${ADDITIONAL_PARAMS})"
+[ "${PROJECT_GROUPS}" ] && arr+=("--project-groups" "${PROJECT_GROUPS}")
+
 /app/bin/cx scan create --project-name "${PROJECT_NAME}" -s "." --branch "${BRANCH#refs/heads/}" --scan-info-format json --agent "Github Action" "${arr[@]}" | tee -i $output_file
 exitCode=${PIPESTATUS[0]}
 


### PR DESCRIPTION
### Description

Assigning a project to a group is a common action. As such an action input provide to users an integrated way to assign groups to their projects.

### References

- #150 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used