### PR TITLE
Addition of New Parameter Flags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,26 @@ inputs:
     required: false
     default: ${{ github.token }}
     description: 'GitHub API Token'
+  global_params:
+    required: false
+    default: ''
+    description: 'Global parameters applied to all cx commands'
+  scan_params:
+    required: false
+    default: ''
+    description: 'Additional parameters for cx scan command only'
+  utils_params:
+    required: false
+    default: ''
+    description: 'Additional parameters for cx utils pr command only'
+  results_params:
+    required: false
+    default: ''
+    description: 'Additional parameters for cx results show command only'
   additional_params:
     required: false
     default: ''
-    description: 'Additional parameters for AST scan'
+    description: '[DEPRECATED] Use scan_params instead. Additional parameters for AST scan'
   repo_name:
     required: false
     default:  ${{ github.event.repository.name }}
@@ -62,6 +78,10 @@ runs:
     - ${{ inputs.github_token }}
     - ${{ inputs.project_name }}
     - ${{ inputs.additional_params }}
+    - ${{ inputs.global_params }}
+    - ${{ inputs.scan_params }}
+    - ${{ inputs.utils_params }}
+    - ${{ inputs.results_params }}
     - ${{ inputs.repo_name }}
     - ${{ inputs.namespace }}
     - ${{ inputs.pr_number }}
@@ -79,6 +99,10 @@ runs:
     BRANCH: ${{ inputs.branch }}
     PROJECT_NAME: ${{ inputs.project_name }}
     ADDITIONAL_PARAMS: ${{ inputs.additional_params }}
+    GLOBAL_PARAMS: ${{ inputs.global_params }}
+    SCAN_PARAMS: ${{ inputs.scan_params }}
+    UTILS_PARAMS: ${{ inputs.utils_params }}
+    RESULTS_PARAMS: ${{ inputs.results_params }}
     REPO_NAME: ${{ inputs.repo_name }}
     NAMESPACE: ${{ inputs.namespace }}
     PR_NUMBER: ${{ inputs.pr_number }}


### PR DESCRIPTION
### Description

New parameters such as additional_params have been introduced.

#### Reason for Change

Previously, additional_params were not passed to the utils and results commands.
As a result:

Debug logs were not visible for these commands.

It was not possible to pass extra flags or configurations specifically for utils and results.

#### Enhancement

To address this limitation, four new parameter flags have been added:
global_params
scan_params
utils_params
results_params

#### Sample yaml file
```yaml
      - name: Run Checkmarx One Scan
        uses: Checkmarx/ast-github-action@main
        with:
          project_name: Test_project
          cx_tenant: ${{ secrets.CX_TENANT }}
          base_uri: https://eu.ast.checkmarx.net/
          cx_client_id: ${{ secrets.CX_CLIENT_ID }}
          cx_client_secret: ${{ secrets.CX_CLIENT_SECRET }}
          global_params: "--debug"
          scan_params: "--scan-types container-security"
          utils_params: "--code-repository-url sample-url.com"
          results_params: "--wait-delay 30"
```
#### Behavior

scan_params, utils_params, and results_params allow passing command-specific flags directly to each respective command.

global_params can be used when the customer wants to provide CLI global flags (scan, utils, and results) through a single global flag.

When global_params is used, **DO NOT USE** CLI Global flags in scan_params, utils_params,  results_params individually.

#### Backward Compatibility
The additional_params flag is retained for backward compatibility to ensure older configurations continue to work without modification.



### Testing

Tested with CLI global flags 
Tested with scan flags
Tested with utils flags
Tested with results flags