### PR TITLE
CISO-918: fix(security): restore iac-security-high threshold to 1

### DIFF
--- a/.github/workflows/checkmarx-one-scan.yml
+++ b/.github/workflows/checkmarx-one-scan.yml
@@ -22,4 +22,4 @@ jobs:
           cx_tenant: ${{ secrets.AST_RND_SCANS_TENANT }}
           cx_client_id: ${{ secrets.AST_RND_SCANS_CLIENT_ID }}
           cx_client_secret: ${{ secrets.AST_RND_SCANS_CLIENT_SECRET }}
-          additional_params: --tags phoenix --threshold "sast-critical=1;sast-high=1;sast-medium=1;sast-low=1;sca-critical=1;sca-high=1;sca-medium=1;sca-low=1;iac-security-critical=1;iac-security-high=2;iac-security-medium=1;iac-security-low=1;"
+          additional_params: --tags phoenix --threshold "sast-critical=1;sast-high=1;sast-medium=1;sast-low=1;sca-critical=1;sca-high=1;sca-medium=1;sca-low=1;iac-security-critical=1;iac-security-high=1;iac-security-medium=1;iac-security-low=1;"


### PR DESCRIPTION
## Summary

Reverts the security threshold change introduced in commit [550d8a18](https://github.com/Checkmarx/ast-github-action/commit/550d8a18) by @cx-anurag-dalke.

## What was changed

`iac-security-high` was silently changed from `1` to `2`, meaning a build would **pass** even if it contains 1 high-severity IaC vulnerability. All other thresholds remained at `1`.

```diff
- iac-security-high=2
+ iac-security-high=1
```

## Why this is a security issue

A threshold of `=2` allows one IaC high-severity finding (e.g. public S3 bucket, overly permissive IAM role, unencrypted database) to pass the security gate silently. Inconsistent with every other threshold in the file and creates a blind spot.

## Related

- CISO-918: https://checkmarx.atlassian.net/browse/CISO-918
- CISO-815: https://checkmarx.atlassian.net/browse/CISO-815
- Offending commit: https://github.com/Checkmarx/ast-github-action/commit/550d8a18