### PR TITLE
Comment out token and contents:write permission in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,16 @@ on:
 jobs:
   release:
     runs-on: cx-public-ubuntu-x64
-    permissions:
-      contents: write
+    # permissions:
+    #   contents: write
     outputs:
       CLI_VERSION: ${{ steps.extract_cli_version.outputs.CLI_VERSION }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        # with:
+        #   token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract full CLI version from Dockerfile
         id: extract_cli_version


### PR DESCRIPTION
## Summary
- Comment out the explicit `token: ${{ secrets.GITHUB_TOKEN }}` on `actions/checkout`.
- Comment out the `permissions: contents: write` block on the `release` job.

## Test plan
- [ ] Confirm intended behavior on next `workflow_dispatch` run of the release workflow.